### PR TITLE
Added RootObj trigger for indent

### DIFF
--- a/src/inim.nim
+++ b/src/inim.nim
@@ -14,7 +14,7 @@ const
     INimVersion = "0.4.1"
     indentSpaces = "    "
     indentTriggers = [",", "=", ":", "var", "let", "const", "type", "import",
-                      "object", "enum"] # endsWith
+                      "object", "RootObj", "enum"] # endsWith
     embeddedCode = staticRead("inimpkg/embedded.nim") # preloaded code into user's session
 
 let


### PR DESCRIPTION
Triggers an indent when defining a type that is an `object of RootObj`

For Example:
```nim
type
    MyObj = ref object of RootObj
    ##Auto indents to the same level as the typedef
        a: string #Attempts to manually indent fail
```