### PR TITLE
Fix inim crash on Termux/Android

### DIFF
--- a/inim.nim
+++ b/inim.nim
@@ -183,7 +183,9 @@ proc bufferRestoreValidCode() =
   if buffer != nil:
     buffer.close()
   buffer = open(bufferSource, fmWrite)
-  buffer.writeLine(EmbeddedCode)
+  buffer.write(EmbeddedCode)
+  if not EmbeddedCode.endsWith("\n"):
+    buffer.write("\n")
   buffer.write(validCode)
   buffer.flushFile()
 


### PR DESCRIPTION
Inim was crashing immediately on startup with an 'invalid indentation' error on line 10. Found that writeLine(EmbeddedCode) was adding an extra newline, which broke the Nim compiler parsing.

Changed to write() with a conditional newline check to fix it.

Tested working on Termux(Android ARM64) with Nim 2.2.4
Inim now starts and runs correctly
Simple REPL operations work as expected.